### PR TITLE
Use FINMIND_BASE_URL for v4 requests

### DIFF
--- a/src/adapters/finmind.ts
+++ b/src/adapters/finmind.ts
@@ -1,7 +1,8 @@
 import fetch from 'node-fetch';
 import { readCache, writeCache } from '../cache.js';
+import { FINMIND_BASE_URL } from '../constants/index.js';
 
-const BASE_URL = 'https://api.finmindtrade.com/api/v4/data';
+const BASE_URL = `${FINMIND_BASE_URL}/data`;
 
 export async function fetchFinMind(
   dataset: string,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
 // 常數定義
 export const API_BASE_URL = 'https://openapi.twse.com.tw';
-export const FINMIND_BASE_URL = 'https://api.finmindtrade.com/api/v3';
+export const FINMIND_BASE_URL = 'https://api.finmindtrade.com/api/v4';
 
 export const API_ENDPOINTS = {
   VALUATION: '/v1/exchangeReport/BWIBBU_d',

--- a/src/utils/finmindClient.ts
+++ b/src/utils/finmindClient.ts
@@ -120,7 +120,7 @@ export class FinMindClient {
       }
     }
 
-    const url = new URL('/api/v4/data', 'https://api.finmindtrade.com');
+    const url = new URL('/data', this.baseUrl);
 
     // 設定基本參數
     url.searchParams.set('dataset', dataset);

--- a/tests/scoring.spec.ts
+++ b/tests/scoring.spec.ts
@@ -10,22 +10,27 @@ const query = db.query as unknown as QueryMock;
 const valuationRows = [
   { stock_no: '1111', per: 10, pbr: 1, dividend_yield: 5 },
   { stock_no: '2222', per: 20, pbr: 2, dividend_yield: 3 },
+  { stock_no: '3333', per: 15, pbr: 1.5, dividend_yield: 4 },
 ];
 const growthRows = [
   { stock_no: '1111', yoy: 10, mom: 5, eps_qoq: 2 },
   { stock_no: '2222', yoy: 5, mom: 2, eps_qoq: 1 },
+  { stock_no: '3333', yoy: 8, mom: 3, eps_qoq: 1.5 },
 ];
 const qualityRows = [
   { stock_no: '1111', roe: 15, gross_margin: 30, op_margin: 20 },
   { stock_no: '2222', roe: 10, gross_margin: 25, op_margin: 15 },
+  { stock_no: '3333', roe: 12, gross_margin: 28, op_margin: 18 },
 ];
 const fundRows = [
   { stock_no: '1111', foreign_net: 100, inv_trust_net: 50 },
   { stock_no: '2222', foreign_net: 50, inv_trust_net: 20 },
+  { stock_no: '3333', foreign_net: 80, inv_trust_net: 30 },
 ];
 const priceRows = [
   { stock_no: '1111', close: 100 },
   { stock_no: '2222', close: 80 },
+  { stock_no: '3333', close: 90 },
 ];
 
 function setupMocks() {
@@ -95,5 +100,11 @@ describe('calcScore', () => {
   it('partial weights are normalized', async () => {
     const res = await calcScore('1111', { valuation: 1 });
     expect(res.total).toBeGreaterThan(0);
+  });
+
+  it('calculates score for additional stock code', async () => {
+    const res = await calcScore('3333');
+    expect(res.total).toBeGreaterThan(0);
+    expect(res.missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- update `FINMIND_BASE_URL` constant to v4
- build request URLs from constant in `FinMindClient`
- reuse constant in FinMind adapter
- expand scoring tests with an extra stock ID

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6852befb62788330b7f28c329abc7b2f