### PR TITLE
Add MA20/60 crossover backtester

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -100,6 +100,12 @@ npm run rank -- --stocks 2330,2454,0050
 npm run explain 2330
 ```
 
+### Backtesting
+
+```bash
+npm run backtest -- --stock 00929
+```
+
 ## 🧪 Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ npm run rank -- --offline
 npm run explain 2330
 ```
 
+### 回測
+
+```bash
+# 執行 MA20/60 交叉回測
+npm run backtest -- --stock 00929
+```
+
 ### 視覺化分析
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "rank": "tsx src/cli/rank.ts",
     "explain": "tsx src/cli/explain.ts",
     "visualize": "tsx src/cli/visualize.ts",
+    "backtest": "tsx src/cli/backtest.ts",
     "update": "tsx src/cli/update.ts",
     "test": "vitest",
     "test:coverage": "vitest --coverage",

--- a/src/backtest/maStrategy.ts
+++ b/src/backtest/maStrategy.ts
@@ -1,0 +1,119 @@
+import { FinMindClient } from '../utils/finmindClient.js';
+
+export interface Trade {
+  date: string;
+  price: number;
+  action: 'buy' | 'sell';
+}
+
+export interface BacktestMetrics {
+  annualReturn: number;
+  sharpe: number;
+  maxDrawdown: number;
+  equityCurve: number[];
+  trades: Trade[];
+}
+
+export interface BacktestOptions {
+  startDate?: string;
+  endDate?: string;
+  prices?: Array<{ date: string; close: number }>;
+}
+
+const FEE_RATE = 0.001425; // 0.1425%
+const SLIPPAGE = 0.0005; // 0.05%
+
+function sma(values: number[], period: number, index: number): number {
+  const slice = values.slice(index - period + 1, index + 1);
+  const sum = slice.reduce((a, b) => a + b, 0);
+  return sum / period;
+}
+
+function calcMetrics(equity: number[]): { annualReturn: number; sharpe: number; maxDrawdown: number } {
+  const returns: number[] = [];
+  for (let i = 1; i < equity.length; i++) {
+    returns.push(equity[i]! / equity[i - 1]! - 1);
+  }
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
+  const std = Math.sqrt(variance);
+  const annualReturn = Math.pow(1 + mean, 252) - 1;
+  const sharpe = std === 0 ? 0 : (mean / std) * Math.sqrt(252);
+
+  let peak = equity[0]!;
+  let maxDrawdown = 0;
+  for (const val of equity) {
+    if (val > peak) peak = val;
+    const draw = val / peak - 1;
+    if (draw < maxDrawdown) maxDrawdown = draw;
+  }
+  return { annualReturn, sharpe, maxDrawdown };
+}
+
+export async function backtestMA(stock: string, opts: BacktestOptions = {}): Promise<BacktestMetrics> {
+  const start = opts.startDate || '2023-01-01';
+  const end = opts.endDate || '2025-06-11';
+  let prices = opts.prices;
+
+  if (!prices) {
+    const client = new FinMindClient();
+    const raw = await client.getStockPrice(stock, start, end);
+    prices = raw.map(r => ({ date: r.date, close: r.close }));
+  }
+
+  prices.sort((a, b) => a.date.localeCompare(b.date));
+  const closes = prices.map(p => p.close);
+  let cash = 100;
+  let shares = 0;
+  let entry = 0;
+  const equity: number[] = [];
+  const trades: Trade[] = [];
+
+  for (let i = 0; i < prices.length; i++) {
+    const close = prices[i]!.close;
+    if (shares > 0) {
+      equity.push(shares * close);
+    } else {
+      equity.push(cash);
+    }
+
+    if (i < 60) continue;
+
+    const ma20 = sma(closes, 20, i);
+    const ma60 = sma(closes, 60, i);
+    const ma20Prev = sma(closes, 20, i - 1);
+    const ma60Prev = sma(closes, 60, i - 1);
+
+    if (shares === 0) {
+      if (ma20 > ma60 && ma20Prev <= ma60Prev) {
+        const buyPrice = close * (1 + SLIPPAGE);
+        shares = cash / (buyPrice * (1 + FEE_RATE));
+        cash = 0;
+        entry = close;
+        trades.push({ date: prices[i]!.date, price: close, action: 'buy' });
+      }
+    } else {
+      const stop = entry * 0.92;
+      if (close < stop || close < ma60) {
+        const sellPrice = close * (1 - SLIPPAGE);
+        cash = shares * sellPrice * (1 - FEE_RATE);
+        shares = 0;
+        trades.push({ date: prices[i]!.date, price: close, action: 'sell' });
+      }
+    }
+  }
+
+  if (shares > 0) {
+    const last = prices[prices.length - 1]!;
+    const sellPrice = last.close * (1 - SLIPPAGE);
+    cash = shares * sellPrice * (1 - FEE_RATE);
+    shares = 0;
+    trades.push({ date: last.date, price: last.close, action: 'sell' });
+    equity[equity.length - 1] = cash;
+  } else {
+    equity[equity.length - 1] = cash;
+  }
+
+  const metrics = calcMetrics(equity);
+  return { ...metrics, equityCurve: equity, trades };
+}

--- a/src/cli/backtest.ts
+++ b/src/cli/backtest.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs';
+import { backtestMA } from '../backtest/maStrategy.js';
+
+export async function run(args: string[] = hideBin(process.argv)): Promise<void> {
+  const argv = yargs(args)
+    .option('stock', { type: 'string', demandOption: true })
+    .help()
+    .parseSync();
+
+  const res = await backtestMA(argv.stock);
+  console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
+  console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);
+  console.log(`Max Drawdown: ${(res.maxDrawdown * 100).toFixed(2)}%`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run();
+}

--- a/tests/backtest.spec.ts
+++ b/tests/backtest.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { backtestMA } from '../src/backtest/maStrategy.js';
+
+type Price = { date: string; close: number };
+
+function genData(): Price[] {
+  const res: Price[] = [];
+  const start = new Date('2023-01-01');
+  for (let i = 0; i < 60; i++) {
+    const d = new Date(start.getTime() + i * 86400000);
+    res.push({ date: d.toISOString().split('T')[0]!, close: 10 });
+  }
+  for (let i = 60; i < 70; i++) {
+    const d = new Date(start.getTime() + i * 86400000);
+    res.push({ date: d.toISOString().split('T')[0]!, close: 12 });
+  }
+  const d71 = new Date(start.getTime() + 70 * 86400000);
+  res.push({ date: d71.toISOString().split('T')[0]!, close: 11 });
+  const d72 = new Date(start.getTime() + 71 * 86400000);
+  res.push({ date: d72.toISOString().split('T')[0]!, close: 7 });
+  for (let i = 72; i < 120; i++) {
+    const d = new Date(start.getTime() + i * 86400000);
+    res.push({ date: d.toISOString().split('T')[0]!, close: 7 });
+  }
+  return res;
+}
+
+describe('MA backtest', () => {
+  it('executes trades based on rules', async () => {
+    const prices = genData();
+    const res = await backtestMA('TEST', { prices });
+    expect(res.trades.length).toBe(2);
+    expect(res.equityCurve[res.equityCurve.length - 1]).toBeLessThan(100);
+  });
+});

--- a/tests/finmindClient.spec.ts
+++ b/tests/finmindClient.spec.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 let fetchMock: any;
-vi.mock('node-fetch', () => ({
-  default: (...args: any[]) => fetchMock(...args),
-}));
+vi.mock('node-fetch', async () => {
+  const actual = await vi.importActual<any>('node-fetch');
+  return {
+    ...actual,
+    default: (...args: any[]) => fetchMock(...args),
+  };
+});
 
 import { FinMindClient } from '../src/utils/finmindClient.js';
+import { defaultCache } from '../src/utils/simpleCache.js';
 
 describe('FinMindClient request generation', () => {
   beforeEach(() => {
+    defaultCache.clear();
     fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ status: 200, msg: 'ok', data: [] }),


### PR DESCRIPTION
## Summary
- implement MA20/60 crossover strategy with 8% stop-loss
- add CLI to run backtests
- document new command in README and README.en
- test backtesting logic
- ensure FinMind client tests clear cache

## Testing
- `npx vitest --run`

------
https://chatgpt.com/codex/tasks/task_e_6852cbdeacf08330a65e5fad6aa7887c