### PR TITLE
Add advanced technical indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **成長因子**: 營收年增率、EPS季增率、營收月增率
 - **品質因子**: ROE、負債比、流動比率、現金流品質
 - **資金流因子**: 外資買賣超、投信動向、法人持股比例
-- **動能因子**: RSI、移動平均、價格動能、成交量比率
+- **動能因子**: RSI、移動平均(MA5/MA20/MA60)、MACD、布林通道、價格動能、成交量比率
 
 ### 🔄 自動化資料處理
 
@@ -109,6 +109,13 @@ npm run fetch-growth        # 成長資料（需 FinMind Token）
 npm run fetch-quality       # 品質資料
 npm run fetch-fund-flow     # 資金流資料（需 FinMind Token）
 npm run fetch-momentum      # 動能資料
+```
+
+執行 `npm run fetch-momentum` 後，系統會計算 MA5、MA20、MA60、MACD 與布林通道等指標，
+並寫入 `technical_indicators` 資料表。範例輸出：
+
+```text
+2330: RSI=68.5, MA20=567.32, 月變化=4.2%
 ```
 
 ### 股票分析

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -130,6 +130,9 @@
 | ma_60 | REAL | 60日移動平均線 (元) | 445.3 |
 | rsi | REAL | RSI相對強弱指標 (0-100) | 67.8 |
 | macd | REAL | MACD指標 | 2.15 |
+| bb_upper | REAL | 布林通道上軌 | 460.1 |
+| bb_middle | REAL | 布林通道中軌 | 448.7 |
+| bb_lower | REAL | 布林通道下軌 | 437.3 |
 
 ### 🛠 系統管理表
 

--- a/migrations/005_add_bollinger_columns.sql
+++ b/migrations/005_add_bollinger_columns.sql
@@ -1,0 +1,4 @@
+-- 新增 Bollinger Band 欄位至 technical_indicators 表
+ALTER TABLE technical_indicators ADD COLUMN bb_upper REAL;
+ALTER TABLE technical_indicators ADD COLUMN bb_middle REAL;
+ALTER TABLE technical_indicators ADD COLUMN bb_lower REAL;

--- a/src/cli/fetch-momentum.ts
+++ b/src/cli/fetch-momentum.ts
@@ -49,9 +49,9 @@ async function main() {
       console.log('\n📈 動能資料樣本:');
       momentumData.forEach(data => {
         const rsi = data.rsi ? data.rsi.toFixed(1) : 'N/A';
-        const sma20 = data.sma_20 ? data.sma_20.toFixed(2) : 'N/A';
+        const ma20 = data.ma_20 ? data.ma_20.toFixed(2) : 'N/A';
         const change = data.price_change_1m ? data.price_change_1m.toFixed(1) + '%' : 'N/A';
-        console.log(`${data.stock_id}: RSI=${rsi}, SMA20=${sma20}, 月變化=${change}`);
+        console.log(`${data.stock_id}: RSI=${rsi}, MA20=${ma20}, 月變化=${change}`);
       });
     }
 

--- a/tests/finmindClient.spec.ts
+++ b/tests/finmindClient.spec.ts
@@ -6,6 +6,7 @@ vi.mock('node-fetch', () => ({
 }));
 
 import { FinMindClient } from '../src/utils/finmindClient.js';
+import { defaultCache } from '../src/utils/simpleCache.js';
 
 describe('FinMindClient request generation', () => {
   beforeEach(() => {
@@ -13,6 +14,8 @@ describe('FinMindClient request generation', () => {
       ok: true,
       json: async () => ({ status: 200, msg: 'ok', data: [] }),
     });
+    vi.spyOn(defaultCache, 'get').mockResolvedValue(null);
+    vi.spyOn(defaultCache, 'set').mockResolvedValue();
   });
 
   it('builds correct URL for getFinancialStatements', async () => {

--- a/tests/technicalIndicators.spec.ts
+++ b/tests/technicalIndicators.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { PriceFetcher } from '../src/fetchers/priceFetcher.js';
+
+function calcEMA(values: number[], period: number): number[] {
+  const k = 2 / (period + 1);
+  let prev = values.slice(0, period).reduce((a, b) => a + b, 0) / period;
+  const ema = [prev];
+  for (let i = period; i < values.length; i++) {
+    prev = values[i] * k + prev * (1 - k);
+    ema.push(prev);
+  }
+  return ema;
+}
+
+describe('technical indicator calculations', () => {
+  const fetcher = new PriceFetcher();
+  const prices = Array.from({ length: 60 }, (_, i) => i + 1);
+
+  it('calculates MA5 correctly', () => {
+    const ma5 = (fetcher as any).calculateSMA(prices, 5) as number[];
+    expect(ma5[ma5.length - 1]).toBe((56 + 57 + 58 + 59 + 60) / 5);
+  });
+
+  it('calculates MACD correctly', () => {
+    const macd = (fetcher as any).calculateMACD(prices) as number[];
+    const ema12 = calcEMA(prices, 12);
+    const ema26 = calcEMA(prices, 26);
+    const expected = ema26.map((val, i) => ema12[i + 14] - val);
+    expect(macd[macd.length - 1]).toBeCloseTo(expected[expected.length - 1], 6);
+  });
+
+  it('calculates Bollinger Bands correctly', () => {
+    const bands = (fetcher as any).calculateBollingerBands(prices, 20) as any;
+    const slice = prices.slice(40);
+    const mean = slice.reduce((a, b) => a + b, 0) / 20;
+    const variance = slice.reduce((sum, p) => sum + Math.pow(p - mean, 2), 0) / 20;
+    const std = Math.sqrt(variance);
+    expect(bands.middle[bands.middle.length - 1]).toBeCloseTo(mean, 5);
+    expect(bands.upper[bands.upper.length - 1]).toBeCloseTo(mean + 2 * std, 5);
+    expect(bands.lower[bands.lower.length - 1]).toBeCloseTo(mean - 2 * std, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- compute MA5/MA60/MACD/Bollinger Bands in momentum and price fetchers
- store new values in `technical_indicators`
- update CLI sample output and docs
- document new DB columns
- add tests for indicator calculations
- database migration for Bollinger columns
- fix FinMindClient tests by disabling cache

## Testing
- `npm install`
- `npx vitest --run`

------
https://chatgpt.com/codex/tasks/task_e_6852cbe036cc8330a7e325ca2806f09b