### PR TITLE
Implement advanced analysis and backtesting

### DIFF
--- a/src/analysis/factorAnalysis.ts
+++ b/src/analysis/factorAnalysis.ts
@@ -1,0 +1,63 @@
+export function pearsonCorrelation(x: number[], y: number[]): number {
+  const n = x.length;
+  if (n === 0 || y.length !== n) return 0;
+  const meanX = x.reduce((a, b) => a + b, 0) / n;
+  const meanY = y.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let denomX = 0;
+  let denomY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = x[i]! - meanX;
+    const dy = y[i]! - meanY;
+    num += dx * dy;
+    denomX += dx * dx;
+    denomY += dy * dy;
+  }
+  if (denomX === 0 || denomY === 0) return 0;
+  return num / Math.sqrt(denomX * denomY);
+}
+
+export interface FactorData {
+  date: string;
+  values: Record<string, number>;
+  returns: Record<string, number>;
+}
+
+export function calcInformationCoefficient(data: FactorData[]): number {
+  const icValues: number[] = [];
+  for (const d of data) {
+    const stocks = Object.keys(d.values);
+    const factors = stocks.map(s => d.values[s]!);
+    const rets = stocks.map(s => d.returns[s] ?? 0);
+    icValues.push(pearsonCorrelation(factors, rets));
+  }
+  return icValues.reduce((a, b) => a + b, 0) / icValues.length;
+}
+
+export function calcFactorDecay(values: Record<string, number[]> , lag: number): Record<string, number> {
+  const res: Record<string, number> = {};
+  for (const [stock, arr] of Object.entries(values)) {
+    if (arr.length <= lag) continue;
+    const x = arr.slice(0, arr.length - lag);
+    const y = arr.slice(lag);
+    res[stock] = pearsonCorrelation(x, y);
+  }
+  return res;
+}
+
+export function calcFactorCorrelation(matrix: Record<string, number[]>): Record<string, Record<string, number>> {
+  const keys = Object.keys(matrix);
+  const result: Record<string, Record<string, number>> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const a = keys[i]!;
+    result[a] = {};
+    for (let j = i + 1; j < keys.length; j++) {
+      const b = keys[j]!;
+      const corr = pearsonCorrelation(matrix[a]!, matrix[b]!);
+      result[a][b] = corr;
+      if (!result[b]) result[b] = {};
+      result[b][a] = corr;
+    }
+  }
+  return result;
+}

--- a/src/analysis/performanceReport.ts
+++ b/src/analysis/performanceReport.ts
@@ -1,0 +1,54 @@
+import { pearsonCorrelation } from './factorAnalysis.js';
+
+export function calcReturns(prices: number[]): number[] {
+  const res: number[] = [];
+  for (let i = 1; i < prices.length; i++) {
+    res.push(prices[i]! / prices[i - 1]! - 1);
+  }
+  return res;
+}
+
+export function annualizeReturn(returns: number[]): number {
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  return Math.pow(1 + mean, 252) - 1;
+}
+
+export function calcVolatility(returns: number[]): number {
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
+  return Math.sqrt(variance) * Math.sqrt(252);
+}
+
+export function calcSharpe(returns: number[], rf = 0): number {
+  const excess = returns.map(r => r - rf / 252);
+  return annualizeReturn(excess) / calcVolatility(excess);
+}
+
+export function maxDrawdown(equity: number[]): number {
+  let peak = equity[0]!;
+  let max = 0;
+  for (const val of equity) {
+    if (val > peak) peak = val;
+    const draw = 1 - val / peak;
+    if (draw > max) max = draw;
+  }
+  return -max;
+}
+
+export function attribution(weights: number[][], returns: number[][]): number[] {
+  const periods = returns[0]!.length;
+  const n = weights.length;
+  const contrib = new Array(n).fill(0);
+  for (let t = 0; t < periods; t++) {
+    for (let i = 0; i < n; i++) {
+      contrib[i] += weights[i]![t]! * returns[i]![t]!;
+    }
+  }
+  return contrib;
+}
+
+export function beta(asset: number[], benchmark: number[]): number {
+  const rA = calcReturns(asset);
+  const rB = calcReturns(benchmark);
+  return pearsonCorrelation(rA, rB) * (calcVolatility(rA) / calcVolatility(rB));
+}

--- a/src/analysis/portfolioOptimizer.ts
+++ b/src/analysis/portfolioOptimizer.ts
@@ -1,0 +1,55 @@
+export function meanVarianceOptimize(expected: number[], cov: number[][]): number[] {
+  const n = expected.length;
+  const inv: number[][] = invertMatrix(cov);
+  const w: number[] = new Array(n).fill(0);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      w[i] += inv[i][j] * expected[j]!;
+    }
+  }
+  const sum = w.reduce((a, b) => a + b, 0);
+  return w.map(x => x / sum);
+}
+
+export function riskParity(cov: number[][]): number[] {
+  const n = cov.length;
+  const vols = cov.map((row, i) => Math.sqrt(row[i]!));
+  const invVol = vols.map(v => (v === 0 ? 0 : 1 / v));
+  const sum = invVol.reduce((a, b) => a + b, 0);
+  return invVol.map(v => v / sum);
+}
+
+function invertMatrix(a: number[][]): number[][] {
+  const n = a.length;
+  const id = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => (i === j ? 1 : 0))
+  );
+  const m = a.map(row => row.slice());
+  for (let i = 0; i < n; i++) {
+    let pivot = m[i][i];
+    if (pivot === 0) {
+      for (let j = i + 1; j < n; j++) {
+        if (m[j][i] !== 0) {
+          [m[i], m[j]] = [m[j], m[i]];
+          [id[i], id[j]] = [id[j], id[i]];
+          pivot = m[i][i];
+          break;
+        }
+      }
+    }
+    if (pivot === 0) throw new Error('Singular matrix');
+    for (let j = 0; j < n; j++) {
+      m[i][j] /= pivot;
+      id[i][j] /= pivot;
+    }
+    for (let k = 0; k < n; k++) {
+      if (k === i) continue;
+      const factor = m[k][i];
+      for (let j = 0; j < n; j++) {
+        m[k][j] -= factor * m[i][j];
+        id[k][j] -= factor * id[i][j];
+      }
+    }
+  }
+  return id;
+}

--- a/src/backtest/maStrategy.ts
+++ b/src/backtest/maStrategy.ts
@@ -1,4 +1,5 @@
 import { FinMindClient } from '../utils/finmindClient.js';
+import { calcMetrics } from './utils.js';
 
 export interface Trade {
   date: string;
@@ -29,26 +30,6 @@ function sma(values: number[], period: number, index: number): number {
   return sum / period;
 }
 
-function calcMetrics(equity: number[]): { annualReturn: number; sharpe: number; maxDrawdown: number } {
-  const returns: number[] = [];
-  for (let i = 1; i < equity.length; i++) {
-    returns.push(equity[i]! / equity[i - 1]! - 1);
-  }
-  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
-  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
-  const std = Math.sqrt(variance);
-  const annualReturn = Math.pow(1 + mean, 252) - 1;
-  const sharpe = std === 0 ? 0 : (mean / std) * Math.sqrt(252);
-
-  let peak = equity[0]!;
-  let maxDrawdown = 0;
-  for (const val of equity) {
-    if (val > peak) peak = val;
-    const draw = val / peak - 1;
-    if (draw < maxDrawdown) maxDrawdown = draw;
-  }
-  return { annualReturn, sharpe, maxDrawdown };
-}
 
 export async function backtestMA(stock: string, opts: BacktestOptions = {}): Promise<BacktestMetrics> {
   const start = opts.startDate || '2023-01-01';

--- a/src/backtest/multiStrategy.ts
+++ b/src/backtest/multiStrategy.ts
@@ -1,0 +1,102 @@
+import { BacktestMetrics, Trade } from './maStrategy.js';
+import { calcMetrics } from './utils.js';
+
+export type Price = { date: string; close: number };
+export type PriceMap = Record<string, Price[]>;
+
+export interface Strategy {
+  selectStocks(dateIndex: number, prices: PriceMap): string[];
+}
+
+export class TopNStrategy implements Strategy {
+  constructor(private scores: Record<string, number[]>, private n: number) {}
+  selectStocks(i: number, _p: PriceMap): string[] {
+    const entries = Object.entries(this.scores).map(([s, arr]) => ({ s, v: arr[i] ?? -Infinity }));
+    return entries
+      .sort((a, b) => b.v - a.v)
+      .slice(0, this.n)
+      .map(e => e.s);
+  }
+}
+
+export class ThresholdStrategy implements Strategy {
+  constructor(private scores: Record<string, number[]>, private threshold: number) {}
+  selectStocks(i: number, _p: PriceMap): string[] {
+    return Object.entries(this.scores)
+      .filter(([, arr]) => (arr[i] ?? -Infinity) >= this.threshold)
+      .map(([s]) => s);
+  }
+}
+
+export class SectorRotationStrategy implements Strategy {
+  constructor(
+    private sectorMap: Record<string, string>,
+    private momentum: Record<string, number[]>,
+    private n: number
+  ) {}
+  selectStocks(i: number, prices: PriceMap): string[] {
+    const sectors = new Map<string, { sec: string; mo: number }>();
+    for (const [stock, arr] of Object.entries(this.momentum)) {
+      const sec = this.sectorMap[stock];
+      const mo = arr[i] ?? -Infinity;
+      const item = sectors.get(sec);
+      if (!item || item.mo < mo) sectors.set(sec, { sec, mo });
+    }
+    return Array.from(sectors.values())
+      .sort((a, b) => b.mo - a.mo)
+      .slice(0, this.n)
+      .flatMap(v => Object.entries(this.sectorMap).filter(([, s]) => s === v.sec).map(([k]) => k));
+  }
+}
+
+export interface BacktestOptions {
+  rebalance: number; // in days
+  startDate?: string;
+  endDate?: string;
+}
+
+export function backtestMulti(prices: PriceMap, strategy: Strategy, opts: BacktestOptions): BacktestMetrics {
+  const allDates = Array.from(new Set(Object.values(prices).flat().map(p => p.date))).sort();
+
+  let cash = 100;
+  const shares: Record<string, number> = {};
+  const equity: number[] = [];
+  const trades: Trade[] = [];
+  const FEE = 0.001425;
+  for (let i = 0; i < allDates.length; i++) {
+    const date = allDates[i]!;
+    for (const [s, series] of Object.entries(prices)) {
+      const price = series.find(p => p.date === date)?.close;
+      if (price && shares[s]) {
+        equity[i] = (equity[i] ?? 0) + shares[s]! * price;
+      }
+    }
+    equity[i] = (equity[i] ?? 0) + cash;
+    if (i % opts.rebalance === 0) {
+      const targets = strategy.selectStocks(i, prices);
+      const current = Object.keys(shares);
+      for (const s of current) {
+        if (!targets.includes(s)) {
+          const price = prices[s]!.find(p => p.date === date)?.close;
+          if (price) {
+            cash += shares[s]! * price * (1 - FEE);
+            trades.push({ date, price, action: 'sell' });
+            delete shares[s];
+          }
+        }
+      }
+      const equalCash = cash / targets.length;
+      for (const s of targets) {
+        const price = prices[s]!.find(p => p.date === date)?.close;
+        if (price) {
+          const qty = equalCash / (price * (1 + FEE));
+          cash -= qty * price * (1 + FEE);
+          shares[s] = (shares[s] ?? 0) + qty;
+          trades.push({ date, price, action: 'buy' });
+        }
+      }
+    }
+  }
+  const metrics = calcMetrics(equity);
+  return { ...metrics, equityCurve: equity, trades };
+}

--- a/src/backtest/utils.ts
+++ b/src/backtest/utils.ts
@@ -1,0 +1,20 @@
+export function calcMetrics(equity: number[]): { annualReturn: number; sharpe: number; maxDrawdown: number } {
+  const returns: number[] = [];
+  for (let i = 1; i < equity.length; i++) {
+    returns.push(equity[i]! / equity[i - 1]! - 1);
+  }
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
+  const std = Math.sqrt(variance);
+  const annualReturn = Math.pow(1 + mean, 252) - 1;
+  const sharpe = std === 0 ? 0 : (mean / std) * Math.sqrt(252);
+
+  let peak = equity[0]!;
+  let maxDrawdown = 0;
+  for (const val of equity) {
+    if (val > peak) peak = val;
+    const draw = val / peak - 1;
+    if (draw < maxDrawdown) maxDrawdown = draw;
+  }
+  return { annualReturn, sharpe, maxDrawdown };
+}

--- a/src/cli/backtest.ts
+++ b/src/cli/backtest.ts
@@ -2,14 +2,54 @@
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs';
 import { backtestMA } from '../backtest/maStrategy.js';
+import { backtestMulti, TopNStrategy, ThresholdStrategy } from '../backtest/multiStrategy.js';
+import { query } from '../db.js';
 
 export async function run(args: string[] = hideBin(process.argv)): Promise<void> {
   const argv = yargs(args)
-    .option('stock', { type: 'string', demandOption: true })
+    .option('stock', { type: 'string' })
+    .option('strategy', {
+      type: 'string',
+      choices: ['ma', 'top_n', 'threshold'],
+      default: 'ma',
+    })
+    .option('n', { type: 'number', default: 5 })
+    .option('threshold', { type: 'number', default: 70 })
+    .option('rebalance', { type: 'number', default: 20 })
     .help()
     .parseSync();
 
-  const res = await backtestMA(argv.stock);
+  if (argv.strategy === 'ma') {
+    if (!argv.stock) throw new Error('stock required for ma strategy');
+    const res = await backtestMA(argv.stock);
+    console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
+    console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);
+    console.log(`Max Drawdown: ${(res.maxDrawdown * 100).toFixed(2)}%`);
+    return;
+  }
+
+  const priceRows = query<any>('SELECT stock_no, date, close FROM price_daily ORDER BY date');
+  const prices: Record<string, { date: string; close: number }[]> = {};
+  for (const row of priceRows) {
+    if (!prices[row.stock_no]) prices[row.stock_no] = [];
+    prices[row.stock_no].push({ date: row.date, close: row.close });
+  }
+
+  const scoreRows = query<any>('SELECT stock_no, date, total_score FROM scores ORDER BY date');
+  const scores: Record<string, number[]> = {};
+  for (const r of scoreRows) {
+    if (!scores[r.stock_no]) scores[r.stock_no] = [];
+    scores[r.stock_no].push(r.total_score);
+  }
+
+  let strategy;
+  if (argv.strategy === 'top_n') {
+    strategy = new TopNStrategy(scores, argv.n);
+  } else {
+    strategy = new ThresholdStrategy(scores, argv.threshold);
+  }
+
+  const res = backtestMulti(prices, strategy, { rebalance: argv.rebalance });
   console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
   console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);
   console.log(`Max Drawdown: ${(res.maxDrawdown * 100).toFixed(2)}%`);

--- a/tests/backtest.spec.ts
+++ b/tests/backtest.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { backtestMA } from '../src/backtest/maStrategy.js';
+import { backtestMulti, TopNStrategy } from '../src/backtest/multiStrategy.js';
 
 type Price = { date: string; close: number };
 
@@ -31,5 +32,16 @@ describe('MA backtest', () => {
     const res = await backtestMA('TEST', { prices });
     expect(res.trades.length).toBe(2);
     expect(res.equityCurve[res.equityCurve.length - 1]).toBeLessThan(100);
+  });
+});
+
+describe('multi-strategy backtest', () => {
+  it('runs top-n strategy', () => {
+    const series = genData();
+    const prices = { AAA: series, BBB: series.map(p => ({ ...p, close: p.close * 1.1 })) };
+    const scores = { AAA: series.map((_, i) => (i < 60 ? 1 : 2)), BBB: series.map(() => 3) };
+    const strategy = new TopNStrategy(scores, 1);
+    const res = backtestMulti(prices, strategy, { rebalance: 20 });
+    expect(res.trades.length).toBeGreaterThan(0);
   });
 });

--- a/tests/factorAnalysis.spec.ts
+++ b/tests/factorAnalysis.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { calcInformationCoefficient, calcFactorDecay, calcFactorCorrelation } from '../src/analysis/factorAnalysis.js';
+
+describe('factor analysis', () => {
+  it('calculates IC', () => {
+    const data = [
+      { date: '1', values: { A: 1, B: 2 }, returns: { A: 0.1, B: 0.2 } },
+      { date: '2', values: { A: 2, B: 1 }, returns: { A: -0.1, B: -0.2 } },
+    ];
+    const ic = calcInformationCoefficient(data);
+    expect(ic).toBeGreaterThan(0.9);
+  });
+
+  it('factor decay', () => {
+    const vals = { A: [1, 2, 3], B: [3, 2, 1] };
+    const decay = calcFactorDecay(vals, 1);
+    expect(Object.keys(decay).length).toBe(2);
+  });
+
+  it('factor correlation', () => {
+    const matrix = { A: [1, 2, 3], B: [1, 2, 4] };
+    const corr = calcFactorCorrelation(matrix);
+    expect(corr.A.B).toBeGreaterThan(0.9);
+  });
+});

--- a/tests/portfolioOptimizer.spec.ts
+++ b/tests/portfolioOptimizer.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { meanVarianceOptimize, riskParity } from '../src/analysis/portfolioOptimizer.js';
+
+describe('portfolio optimizer', () => {
+  it('mean variance weights sum to 1', () => {
+    const w = meanVarianceOptimize([0.1, 0.2], [[0.1, 0], [0, 0.2]]);
+    const sum = w.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+
+  it('risk parity produces weights', () => {
+    const w = riskParity([[0.1, 0], [0, 0.4]]);
+    expect(w.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add factor effectiveness analysis utilities
- implement portfolio optimization helpers
- create multi-strategy backtesting engine
- expose strategy options in `backtest` CLI
- provide performance metrics helpers
- test new modules

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685583d5fab48330817753978e947e3b