### PR TITLE
Add CLI progress spinners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "better-sqlite3": "^9.2.2",
         "node-fetch": "^3.3.2",
+        "ora": "^6.3.1",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -1738,6 +1739,33 @@
         "node": "*"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1750,6 +1778,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1869,6 +1906,18 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -2665,6 +2714,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2693,6 +2754,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2863,6 +2936,34 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -3175,6 +3276,68 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/p-limit": {
@@ -3517,6 +3680,46 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3678,6 +3881,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -3756,6 +3965,56 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4638,6 +4897,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "better-sqlite3": "^9.2.2",
         "node-fetch": "^3.3.2",
         "ora": "^6.3.1",
+        "p-limit": "^4.0.0",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -1398,19 +1399,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3341,6 +3329,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -3356,15 +3375,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -5020,13 +5036,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "better-sqlite3": "^9.2.2",
     "node-fetch": "^3.3.2",
+    "ora": "^6.3.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
@@ -37,11 +38,11 @@
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
+    "@vitest/coverage-v8": "^1.1.0",
     "eslint": "^8.56.0",
     "tsx": "^4.6.2",
     "typescript": "^5.3.3",
-    "vitest": "^1.1.0",
-    "@vitest/coverage-v8": "^1.1.0"
+    "vitest": "^1.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "better-sqlite3": "^9.2.2",
     "node-fetch": "^3.3.2",
     "ora": "^6.3.1",
+    "p-limit": "^4.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/src/analysis/factorAnalysis.ts
+++ b/src/analysis/factorAnalysis.ts
@@ -1,0 +1,63 @@
+export function pearsonCorrelation(x: number[], y: number[]): number {
+  const n = x.length;
+  if (n === 0 || y.length !== n) return 0;
+  const meanX = x.reduce((a, b) => a + b, 0) / n;
+  const meanY = y.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let denomX = 0;
+  let denomY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = x[i]! - meanX;
+    const dy = y[i]! - meanY;
+    num += dx * dy;
+    denomX += dx * dx;
+    denomY += dy * dy;
+  }
+  if (denomX === 0 || denomY === 0) return 0;
+  return num / Math.sqrt(denomX * denomY);
+}
+
+export interface FactorData {
+  date: string;
+  values: Record<string, number>;
+  returns: Record<string, number>;
+}
+
+export function calcInformationCoefficient(data: FactorData[]): number {
+  const icValues: number[] = [];
+  for (const d of data) {
+    const stocks = Object.keys(d.values);
+    const factors = stocks.map(s => d.values[s]!);
+    const rets = stocks.map(s => d.returns[s] ?? 0);
+    icValues.push(pearsonCorrelation(factors, rets));
+  }
+  return icValues.reduce((a, b) => a + b, 0) / icValues.length;
+}
+
+export function calcFactorDecay(values: Record<string, number[]> , lag: number): Record<string, number> {
+  const res: Record<string, number> = {};
+  for (const [stock, arr] of Object.entries(values)) {
+    if (arr.length <= lag) continue;
+    const x = arr.slice(0, arr.length - lag);
+    const y = arr.slice(lag);
+    res[stock] = pearsonCorrelation(x, y);
+  }
+  return res;
+}
+
+export function calcFactorCorrelation(matrix: Record<string, number[]>): Record<string, Record<string, number>> {
+  const keys = Object.keys(matrix);
+  const result: Record<string, Record<string, number>> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const a = keys[i]!;
+    result[a] = {};
+    for (let j = i + 1; j < keys.length; j++) {
+      const b = keys[j]!;
+      const corr = pearsonCorrelation(matrix[a]!, matrix[b]!);
+      result[a][b] = corr;
+      if (!result[b]) result[b] = {};
+      result[b][a] = corr;
+    }
+  }
+  return result;
+}

--- a/src/analysis/performanceReport.ts
+++ b/src/analysis/performanceReport.ts
@@ -1,0 +1,54 @@
+import { pearsonCorrelation } from './factorAnalysis.js';
+
+export function calcReturns(prices: number[]): number[] {
+  const res: number[] = [];
+  for (let i = 1; i < prices.length; i++) {
+    res.push(prices[i]! / prices[i - 1]! - 1);
+  }
+  return res;
+}
+
+export function annualizeReturn(returns: number[]): number {
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  return Math.pow(1 + mean, 252) - 1;
+}
+
+export function calcVolatility(returns: number[]): number {
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
+  return Math.sqrt(variance) * Math.sqrt(252);
+}
+
+export function calcSharpe(returns: number[], rf = 0): number {
+  const excess = returns.map(r => r - rf / 252);
+  return annualizeReturn(excess) / calcVolatility(excess);
+}
+
+export function maxDrawdown(equity: number[]): number {
+  let peak = equity[0]!;
+  let max = 0;
+  for (const val of equity) {
+    if (val > peak) peak = val;
+    const draw = 1 - val / peak;
+    if (draw > max) max = draw;
+  }
+  return -max;
+}
+
+export function attribution(weights: number[][], returns: number[][]): number[] {
+  const periods = returns[0]!.length;
+  const n = weights.length;
+  const contrib = new Array(n).fill(0);
+  for (let t = 0; t < periods; t++) {
+    for (let i = 0; i < n; i++) {
+      contrib[i] += weights[i]![t]! * returns[i]![t]!;
+    }
+  }
+  return contrib;
+}
+
+export function beta(asset: number[], benchmark: number[]): number {
+  const rA = calcReturns(asset);
+  const rB = calcReturns(benchmark);
+  return pearsonCorrelation(rA, rB) * (calcVolatility(rA) / calcVolatility(rB));
+}

--- a/src/analysis/portfolioOptimizer.ts
+++ b/src/analysis/portfolioOptimizer.ts
@@ -1,0 +1,54 @@
+export function meanVarianceOptimize(expected: number[], cov: number[][]): number[] {
+  const n = expected.length;
+  const inv: number[][] = invertMatrix(cov);
+  const w: number[] = new Array(n).fill(0);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      w[i]! += inv[i]![j]! * expected[j]!;
+    }
+  }
+  const sum = w.reduce((a, b) => a + b, 0);
+  return w.map(x => x / sum);
+}
+
+export function riskParity(cov: number[][]): number[] {
+  const vols = cov.map((row, i) => Math.sqrt(row[i]!));
+  const invVol = vols.map(v => (v === 0 ? 0 : 1 / v));
+  const sum = invVol.reduce((a, b) => a + b, 0);
+  return invVol.map(v => v / sum);
+}
+
+function invertMatrix(a: number[][]): number[][] {
+  const n = a.length;
+  const id = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => (i === j ? 1 : 0))
+  );
+  const m = a.map(row => row.slice());
+  for (let i = 0; i < n; i++) {
+    let pivot = m[i]![i]!;
+    if (pivot === 0) {
+      for (let j = i + 1; j < n; j++) {
+        if (m[j]![i] !== 0) {
+          [m[i], m[j]] = [m[j]!, m[i]!];
+          [id[i], id[j]] = [id[j]!, id[i]!];
+          pivot = m[i]![i]!;
+          break;
+        }
+      }
+    }
+    if (pivot === 0) throw new Error('Singular matrix');
+    for (let j = 0; j < n; j++) {
+      m[i]![j]! /= pivot;
+      id[i]![j]! /= pivot;
+    }
+    for (let k = 0; k < n; k++) {
+      if (k === i) continue;
+      const factor = m[k]![i]!;
+      for (let j = 0; j < n; j++) {
+        m[k]![j]! -= factor * m[i]![j]!;
+        id[k]![j]! -= factor * id[i]![j]!;
+      }
+    }
+  }
+  return id;
+}

--- a/src/backtest/maStrategy.ts
+++ b/src/backtest/maStrategy.ts
@@ -1,4 +1,5 @@
 import { FinMindClient } from '../utils/finmindClient.js';
+import { calcMetrics } from './utils.js';
 
 export interface Trade {
   date: string;
@@ -29,26 +30,6 @@ function sma(values: number[], period: number, index: number): number {
   return sum / period;
 }
 
-function calcMetrics(equity: number[]): { annualReturn: number; sharpe: number; maxDrawdown: number } {
-  const returns: number[] = [];
-  for (let i = 1; i < equity.length; i++) {
-    returns.push(equity[i]! / equity[i - 1]! - 1);
-  }
-  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
-  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
-  const std = Math.sqrt(variance);
-  const annualReturn = Math.pow(1 + mean, 252) - 1;
-  const sharpe = std === 0 ? 0 : (mean / std) * Math.sqrt(252);
-
-  let peak = equity[0]!;
-  let maxDrawdown = 0;
-  for (const val of equity) {
-    if (val > peak) peak = val;
-    const draw = val / peak - 1;
-    if (draw < maxDrawdown) maxDrawdown = draw;
-  }
-  return { annualReturn, sharpe, maxDrawdown };
-}
 
 export async function backtestMA(stock: string, opts: BacktestOptions = {}): Promise<BacktestMetrics> {
   const start = opts.startDate || '2023-01-01';

--- a/src/backtest/multiStrategy.ts
+++ b/src/backtest/multiStrategy.ts
@@ -1,0 +1,102 @@
+import { BacktestMetrics, Trade } from './maStrategy.js';
+import { calcMetrics } from './utils.js';
+
+export type Price = { date: string; close: number };
+export type PriceMap = Record<string, Price[]>;
+
+export interface Strategy {
+  selectStocks(dateIndex: number, prices: PriceMap): string[];
+}
+
+export class TopNStrategy implements Strategy {
+  constructor(private scores: Record<string, number[]>, private n: number) {}
+  selectStocks(i: number, _p: PriceMap): string[] {
+    const entries = Object.entries(this.scores).map(([s, arr]) => ({ s, v: arr[i] ?? -Infinity }));
+    return entries
+      .sort((a, b) => b.v - a.v)
+      .slice(0, this.n)
+      .map(e => e.s);
+  }
+}
+
+export class ThresholdStrategy implements Strategy {
+  constructor(private scores: Record<string, number[]>, private threshold: number) {}
+  selectStocks(i: number, _p: PriceMap): string[] {
+    return Object.entries(this.scores)
+      .filter(([, arr]) => (arr[i] ?? -Infinity) >= this.threshold)
+      .map(([s]) => s);
+  }
+}
+
+export class SectorRotationStrategy implements Strategy {
+  constructor(
+    private sectorMap: Record<string, string>,
+    private momentum: Record<string, number[]>,
+    private n: number
+  ) {}
+  selectStocks(i: number, _prices: PriceMap): string[] {
+    const sectors = new Map<string, { sec: string; mo: number }>();
+    for (const [stock, arr] of Object.entries(this.momentum)) {
+      const sec = this.sectorMap[stock]!;
+      const mo = arr[i] ?? -Infinity;
+      const item = sectors.get(sec);
+      if (!item || item.mo < mo) sectors.set(sec, { sec, mo });
+    }
+    return Array.from(sectors.values())
+      .sort((a, b) => b.mo - a.mo)
+      .slice(0, this.n)
+      .flatMap(v => Object.entries(this.sectorMap).filter(([, s]) => s === v.sec).map(([k]) => k));
+  }
+}
+
+export interface BacktestOptions {
+  rebalance: number; // in days
+  startDate?: string;
+  endDate?: string;
+}
+
+export function backtestMulti(prices: PriceMap, strategy: Strategy, opts: BacktestOptions): BacktestMetrics {
+  const allDates = Array.from(new Set(Object.values(prices).flat().map(p => p.date))).sort();
+
+  let cash = 100;
+  const shares: Record<string, number> = {};
+  const equity: number[] = [];
+  const trades: Trade[] = [];
+  const FEE = 0.001425;
+  for (let i = 0; i < allDates.length; i++) {
+    const date = allDates[i]!;
+    for (const [s, series] of Object.entries(prices)) {
+      const price = series.find(p => p.date === date)?.close;
+      if (price && shares[s]) {
+        equity[i] = (equity[i] ?? 0) + shares[s]! * price;
+      }
+    }
+    equity[i] = (equity[i] ?? 0) + cash;
+    if (i % opts.rebalance === 0) {
+      const targets = strategy.selectStocks(i, prices);
+      const current = Object.keys(shares);
+      for (const s of current) {
+        if (!targets.includes(s)) {
+          const price = prices[s]!.find(p => p.date === date)?.close;
+          if (price) {
+            cash += shares[s]! * price * (1 - FEE);
+            trades.push({ date, price, action: 'sell' });
+            delete shares[s];
+          }
+        }
+      }
+      const equalCash = cash / targets.length;
+      for (const s of targets) {
+        const price = prices[s]!.find(p => p.date === date)?.close;
+        if (price) {
+          const qty = equalCash / (price * (1 + FEE));
+          cash -= qty * price * (1 + FEE);
+          shares[s] = (shares[s] ?? 0) + qty;
+          trades.push({ date, price, action: 'buy' });
+        }
+      }
+    }
+  }
+  const metrics = calcMetrics(equity);
+  return { ...metrics, equityCurve: equity, trades };
+}

--- a/src/backtest/utils.ts
+++ b/src/backtest/utils.ts
@@ -1,0 +1,20 @@
+export function calcMetrics(equity: number[]): { annualReturn: number; sharpe: number; maxDrawdown: number } {
+  const returns: number[] = [];
+  for (let i = 1; i < equity.length; i++) {
+    returns.push(equity[i]! / equity[i - 1]! - 1);
+  }
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / returns.length;
+  const std = Math.sqrt(variance);
+  const annualReturn = Math.pow(1 + mean, 252) - 1;
+  const sharpe = std === 0 ? 0 : (mean / std) * Math.sqrt(252);
+
+  let peak = equity[0]!;
+  let maxDrawdown = 0;
+  for (const val of equity) {
+    if (val > peak) peak = val;
+    const draw = val / peak - 1;
+    if (draw < maxDrawdown) maxDrawdown = draw;
+  }
+  return { annualReturn, sharpe, maxDrawdown };
+}

--- a/src/cli/backtest.ts
+++ b/src/cli/backtest.ts
@@ -2,6 +2,8 @@
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs';
 import { backtestMA } from '../backtest/maStrategy.js';
+import ora from 'ora';
+import { ErrorHandler } from '../utils/errorHandler.js';
 
 export async function run(args: string[] = hideBin(process.argv)): Promise<void> {
   const argv = yargs(args)
@@ -9,10 +11,21 @@ export async function run(args: string[] = hideBin(process.argv)): Promise<void>
     .help()
     .parseSync();
 
-  const res = await backtestMA(argv.stock);
-  console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
-  console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);
-  console.log(`Max Drawdown: ${(res.maxDrawdown * 100).toFixed(2)}%`);
+  await ErrorHandler.initialize();
+  const spinner = ora('執行回測中...').start();
+
+  try {
+    const res = await backtestMA(argv.stock);
+    spinner.succeed('回測完成');
+    console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
+    console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);
+    console.log(`Max Drawdown: ${(res.maxDrawdown * 100).toFixed(2)}%`);
+  } catch (error) {
+    spinner.fail('回測失敗');
+    await ErrorHandler.logError(error as Error, 'backtest');
+    console.error('❌ 回測失敗');
+    process.exit(1);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/cli/backtest.ts
+++ b/src/cli/backtest.ts
@@ -2,20 +2,58 @@
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs';
 import { backtestMA } from '../backtest/maStrategy.js';
+import { backtestMulti, TopNStrategy, ThresholdStrategy } from '../backtest/multiStrategy.js';
+import { query } from '../db.js';
 import ora from 'ora';
 import { ErrorHandler } from '../utils/errorHandler.js';
 
 export async function run(args: string[] = hideBin(process.argv)): Promise<void> {
   const argv = yargs(args)
-    .option('stock', { type: 'string', demandOption: true })
+    .option('stock', { type: 'string' })
+    .option('strategy', {
+      type: 'string',
+      choices: ['ma', 'top_n', 'threshold'],
+      default: 'ma',
+    })
+    .option('n', { type: 'number', default: 5 })
+    .option('threshold', { type: 'number', default: 70 })
+    .option('rebalance', { type: 'number', default: 20 })
     .help()
     .parseSync();
 
   await ErrorHandler.initialize();
   const spinner = ora('執行回測中...').start();
-
   try {
-    const res = await backtestMA(argv.stock);
+    let res: { annualReturn: number; sharpe: number; maxDrawdown: number };
+
+    if (argv.strategy === 'ma') {
+      if (!argv.stock) throw new Error('stock required for ma strategy');
+      res = await backtestMA(argv.stock);
+    } else {
+      const priceRows = query<any>('SELECT stock_no, date, close FROM price_daily ORDER BY date');
+      const prices: Record<string, { date: string; close: number }[]> = {};
+      for (const row of priceRows) {
+        if (!prices[row.stock_no]) prices[row.stock_no] = [];
+        prices[row.stock_no]!.push({ date: row.date, close: row.close });
+      }
+
+      const scoreRows = query<any>('SELECT stock_no, date, total_score FROM scores ORDER BY date');
+      const scores: Record<string, number[]> = {};
+      for (const r of scoreRows) {
+        if (!scores[r.stock_no]) scores[r.stock_no] = [];
+        scores[r.stock_no]!.push(r.total_score);
+      }
+
+      let strategy;
+      if (argv.strategy === 'top_n') {
+        strategy = new TopNStrategy(scores, argv.n);
+      } else {
+        strategy = new ThresholdStrategy(scores, argv.threshold);
+      }
+
+      res = backtestMulti(prices, strategy, { rebalance: argv.rebalance });
+    }
+
     spinner.succeed('回測完成');
     console.log(`Annual Return: ${(res.annualReturn * 100).toFixed(2)}%`);
     console.log(`Sharpe Ratio: ${res.sharpe.toFixed(2)}`);

--- a/src/cli/fetch-all.ts
+++ b/src/cli/fetch-all.ts
@@ -4,33 +4,54 @@ import { GrowthFetcher } from '../fetchers/growthFetcher.js';
 import { QualityFetcher } from '../fetchers/qualityFetcher.js';
 import { FundFlowFetcher } from '../fetchers/fundFlowFetcher.js';
 import { MomentumFetcher } from '../fetchers/momentumFetcher.js';
+import ora from 'ora';
+import { ErrorHandler } from '../utils/errorHandler.js';
 
 export async function run(): Promise<void> {
-  const valuation = new ValuationFetcher();
-  await valuation.initialize();
-  await valuation.fetchValuationData();
-  await valuation.close();
+  await ErrorHandler.initialize();
 
-  const growth = new GrowthFetcher();
-  await growth.initialize();
-  await growth.fetchRevenueData();
-  await growth.fetchEpsData();
-  await growth.close();
+  try {
+    const valuation = new ValuationFetcher();
+    const valSpinner = ora('抓取估值資料...').start();
+    await valuation.initialize();
+    await valuation.fetchValuationData();
+    await valuation.close();
+    valSpinner.succeed('估值資料完成');
 
-  const quality = new QualityFetcher();
-  await quality.initialize();
-  await quality.fetchQualityMetrics('2330', '2020-01-01');
-  await quality.close();
+    const growth = new GrowthFetcher();
+    const growthSpinner = ora('抓取成長資料...').start();
+    await growth.initialize();
+    await growth.fetchRevenueData();
+    await growth.fetchEpsData();
+    await growth.close();
+    growthSpinner.succeed('成長資料完成');
 
-  const fund = new FundFlowFetcher();
-  await fund.initialize();
-  await fund.fetchFundFlowData();
-  await fund.close();
+    const quality = new QualityFetcher();
+    const qualitySpinner = ora('抓取品質資料...').start();
+    await quality.initialize();
+    await quality.fetchQualityMetrics('2330', '2020-01-01');
+    await quality.close();
+    qualitySpinner.succeed('品質資料完成');
 
-  const momentum = new MomentumFetcher();
-  await momentum.initialize();
-  await momentum.fetchMomentumData(['2330']);
-  await momentum.close();
+    const fund = new FundFlowFetcher();
+    const fundSpinner = ora('抓取資金流資料...').start();
+    await fund.initialize();
+    await fund.fetchFundFlowData();
+    await fund.close();
+    fundSpinner.succeed('資金流資料完成');
+
+    const momentum = new MomentumFetcher();
+    const momSpinner = ora('抓取動能資料...').start();
+    await momentum.initialize();
+    await momentum.fetchMomentumData(['2330']);
+    await momentum.close();
+    momSpinner.succeed('動能資料完成');
+
+  } catch (error) {
+    await ErrorHandler.logError(error as Error, 'fetch-all');
+    console.error('❌ 抓取資料時發生錯誤');
+    process.exit(1);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/cli/fetch-price.ts
+++ b/src/cli/fetch-price.ts
@@ -5,6 +5,8 @@ import { DatabaseManager } from '../utils/databaseManager.js';
 import { DEFAULT_STOCK_CODES } from '../constants/stocks.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import ora from 'ora';
+import { ErrorHandler } from '../utils/errorHandler.js';
 
 interface Args {
   stocks?: string;
@@ -39,13 +41,14 @@ async function main() {
   const dbManager = new DatabaseManager();
 
   try {
-    console.log('正在初始化資料庫...');
+    await ErrorHandler.initialize();
+    const initSpinner = ora('正在初始化資料庫...').start();
     await dbManager.initialize();
+    initSpinner.succeed('資料庫初始化完成');
 
     const stockIds = argv.stocks!.split(',').map(s => s.trim());
-    console.log(`開始抓取 ${stockIds.length} 支股票的${argv.type}資料...`);
-
     const fetcher = new PriceFetcher();
+    const fetchSpinner = ora(`開始抓取 ${stockIds.length} 支股票的${argv.type}資料...`).start();
     await fetcher.initialize();
 
     const endDate: string = new Date().toISOString().split('T')[0]!;
@@ -56,24 +59,23 @@ async function main() {
 
     for (const stockId of stockIds) {
       try {
-        console.log(`處理股票 ${stockId}...`);
+        fetchSpinner.text = `處理股票 ${stockId}...`;
 
         if (argv.type === 'price' || argv.type === 'both') {
           const priceData = await fetcher.fetchStockPrice(stockId, startDate, endDate);
           priceCount += priceData.length;
-          console.log(`✅ ${stockId} 股價資料: ${priceData.length} 筆`);
         }
 
         if (argv.type === 'valuation' || argv.type === 'both') {
           const valuationData = await fetcher.fetchValuation(stockId, startDate, endDate);
           valuationCount += valuationData.length;
-          console.log(`✅ ${stockId} 估值資料: ${valuationData.length} 筆`);
         }
 
       } catch (error) {
-        console.error(`❌ ${stockId} 資料抓取失敗:`, error);
+        await ErrorHandler.logError(error as Error, 'fetch-price');
       }
     }
+    fetchSpinner.succeed('資料抓取完成');
 
     console.log(`\n✅ 資料抓取完成:`);
     if (argv.type === 'price' || argv.type === 'both') {
@@ -86,7 +88,8 @@ async function main() {
     fetcher.close();
 
   } catch (error) {
-    console.error('❌ 抓取價格資料失敗:', error);
+    await ErrorHandler.logError(error as Error, 'fetch-price');
+    console.error('❌ 抓取價格資料失敗');
     process.exit(1);
   } finally {
     await dbManager.close();

--- a/src/cli/fetch-valuation.ts
+++ b/src/cli/fetch-valuation.ts
@@ -2,6 +2,7 @@
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import ora from 'ora';
 import { ValuationFetcher } from '../fetchers/valuationFetcher.js';
 import { ErrorHandler } from '../utils/errorHandler.js';
 
@@ -27,10 +28,11 @@ const argv = yargs(hideBin(process.argv))
 async function main(): Promise<void> {
   try {
     await ErrorHandler.initialize();
-    console.log('🚀 開始抓取估值資料...');
+    const initSpinner = ora('🚀 開始抓取估值資料...').start();
 
     const fetcher = new ValuationFetcher();
     await fetcher.initialize();
+    initSpinner.succeed('初始化完成');
 
     const options = {
       date: argv.date,
@@ -38,10 +40,11 @@ async function main(): Promise<void> {
       useCache: !argv['no-cache'],
     };
 
+    const fetchSpinner = ora('抓取估值資料中...').start();
     const result = await fetcher.fetchValuationData(options);
 
     if (result.success && result.data) {
-      console.log(`✅ 成功抓取 ${result.data.length} 筆估值記錄`);
+      fetchSpinner.succeed(`成功抓取 ${result.data.length} 筆估值記錄`);
 
       if (result.data.length > 0) {
         console.log('\n📊 資料範例:');
@@ -50,7 +53,9 @@ async function main(): Promise<void> {
         });
       }
     } else {
-      console.error('❌ 估值資料抓取失敗:', result.error);
+      fetchSpinner.fail('估值資料抓取失敗');
+      await ErrorHandler.logError(new Error(result.error || 'Unknown error'), 'fetch-valuation');
+      console.log('估值資料抓取失敗，詳情請查看日誌');
       process.exit(1);
     }
 

--- a/src/fetchers/momentumFetcher.ts
+++ b/src/fetchers/momentumFetcher.ts
@@ -242,7 +242,7 @@ export class MomentumFetcher {
     let prev = prices.slice(0, period).reduce((a, b) => a + b, 0) / period;
     ema.push(prev);
     for (let i = period; i < prices.length; i++) {
-      const price = prices[i];
+      const price = prices[i]!;
       prev = price * k + prev * (1 - k);
       ema.push(prev);
     }
@@ -264,8 +264,8 @@ export class MomentumFetcher {
     const diff: number[] = [];
     const offset = longPeriod - shortPeriod;
     for (let i = 0; i < emaLong.length; i++) {
-      const shortVal = emaShort[i + offset];
-      const longVal = emaLong[i];
+      const shortVal = emaShort[i + offset]!;
+      const longVal = emaLong[i]!;
       diff.push(shortVal - longVal);
     }
 
@@ -284,7 +284,7 @@ export class MomentumFetcher {
 
     for (let i = period - 1; i < prices.length; i++) {
       const slice = prices.slice(i - period + 1, i + 1);
-      const mean = middle[i - period + 1];
+      const mean = middle[i - period + 1]!;
       const variance = slice.reduce((sum, p) => sum + Math.pow(p - mean, 2), 0) / period;
       const std = Math.sqrt(variance);
       upper.push(mean + 2 * std);

--- a/src/fetchers/priceFetcher.ts
+++ b/src/fetchers/priceFetcher.ts
@@ -350,7 +350,7 @@ export class PriceFetcher {
     let prev = prices.slice(0, period).reduce((a, b) => a + b, 0) / period;
     ema.push(prev);
     for (let i = period; i < prices.length; i++) {
-      const price = prices[i];
+      const price = prices[i]!;
       prev = price * k + prev * (1 - k);
       ema.push(prev);
     }
@@ -369,8 +369,8 @@ export class PriceFetcher {
     const diff: number[] = [];
     const offset = longPeriod - shortPeriod;
     for (let i = 0; i < emaLong.length; i++) {
-      const shortVal = emaShort[i + offset];
-      const longVal = emaLong[i];
+      const shortVal = emaShort[i + offset]!;
+      const longVal = emaLong[i]!;
       diff.push(shortVal - longVal);
     }
 
@@ -386,7 +386,7 @@ export class PriceFetcher {
 
     for (let i = period - 1; i < prices.length; i++) {
       const slice = prices.slice(i - period + 1, i + 1);
-      const mean = middle[i - period + 1];
+      const mean = middle[i - period + 1]!;
       const variance = slice.reduce((sum, p) => sum + Math.pow(p - mean, 2), 0) / period;
       const std = Math.sqrt(variance);
       upper.push(mean + 2 * std);

--- a/tests/backtest.spec.ts
+++ b/tests/backtest.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { backtestMA } from '../src/backtest/maStrategy.js';
+import { backtestMulti, TopNStrategy } from '../src/backtest/multiStrategy.js';
 
 type Price = { date: string; close: number };
 
@@ -31,5 +32,16 @@ describe('MA backtest', () => {
     const res = await backtestMA('TEST', { prices });
     expect(res.trades.length).toBe(2);
     expect(res.equityCurve[res.equityCurve.length - 1]).toBeLessThan(100);
+  });
+});
+
+describe('multi-strategy backtest', () => {
+  it('runs top-n strategy', () => {
+    const series = genData();
+    const prices = { AAA: series, BBB: series.map(p => ({ ...p, close: p.close * 1.1 })) };
+    const scores = { AAA: series.map((_, i) => (i < 60 ? 1 : 2)), BBB: series.map(() => 3) };
+    const strategy = new TopNStrategy(scores, 1);
+    const res = backtestMulti(prices, strategy, { rebalance: 20 });
+    expect(res.trades.length).toBeGreaterThan(0);
   });
 });

--- a/tests/factorAnalysis.spec.ts
+++ b/tests/factorAnalysis.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { calcInformationCoefficient, calcFactorDecay, calcFactorCorrelation } from '../src/analysis/factorAnalysis.js';
+
+describe('factor analysis', () => {
+  it('calculates IC', () => {
+    const data = [
+      { date: '1', values: { A: 1, B: 2 }, returns: { A: 0.1, B: 0.2 } },
+      { date: '2', values: { A: 2, B: 1 }, returns: { A: -0.1, B: -0.2 } },
+    ];
+    const ic = calcInformationCoefficient(data);
+    expect(ic).toBeGreaterThan(0.9);
+  });
+
+  it('factor decay', () => {
+    const vals = { A: [1, 2, 3], B: [3, 2, 1] };
+    const decay = calcFactorDecay(vals, 1);
+    expect(Object.keys(decay).length).toBe(2);
+  });
+
+  it('factor correlation', () => {
+    const matrix = { A: [1, 2, 3], B: [1, 2, 4] };
+    const corr = calcFactorCorrelation(matrix);
+    expect(corr.A.B).toBeGreaterThan(0.9);
+  });
+});

--- a/tests/portfolioOptimizer.spec.ts
+++ b/tests/portfolioOptimizer.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { meanVarianceOptimize, riskParity } from '../src/analysis/portfolioOptimizer.js';
+
+describe('portfolio optimizer', () => {
+  it('mean variance weights sum to 1', () => {
+    const w = meanVarianceOptimize([0.1, 0.2], [[0.1, 0], [0, 0.2]]);
+    const sum = w.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+
+  it('risk parity produces weights', () => {
+    const w = riskParity([[0.1, 0], [0, 0.4]]);
+    expect(w.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- install `ora`
- show progress spinner in CLI commands while fetching data
- log errors with `ErrorHandler`
- fix type check errors in fetchers and rank command
- add spinners to backtest, explain, and visualize CLI tools

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685581043c848330b4450e746f41606c