### PR TITLE
Add CLI usage document

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,14 @@ cd taiwan-stock-screener
 npm install
 ```
 
-3. **編譯專案**
+3. **編譯專案**：`npm run build`
 
-```bash
-npm run build
-```
-
-4. **初始化資料庫**
-
-```bash
-# 資料庫會在第一次運行時自動創建
-npm run fetch-all
-```
+4. **初始化資料庫**：`npm run fetch-all`
 
 ## 🎮 使用指南
+更多 CLI 指令請參見 [docs/CLI_USAGE.md](docs/CLI_USAGE.md)
+
+
 
 ### 初次設定
 
@@ -92,99 +86,6 @@ npm run fetch-all
    # FINMIND_TOKEN=your_token_here
    ```
 
-2. **測試 FinMind API 連線**：
-   ```bash
-   npm run test:finmind
-   ```
-
-### 資料抓取
-
-```bash
-# 抓取所有資料
-npm run fetch-all
-
-# 抓取特定因子資料
-npm run fetch-valuation    # 估值資料
-npm run fetch-growth        # 成長資料（需 FinMind Token）
-npm run fetch-quality       # 品質資料
-npm run fetch-fund-flow     # 資金流資料（需 FinMind Token）
-npm run fetch-momentum      # 動能資料
-```
-
-執行 `npm run fetch-momentum` 後，系統會計算 MA5、MA20、MA60、MACD 與布林通道等指標，
-並寫入 `technical_indicators` 資料表。範例輸出：
-
-```text
-2330: RSI=68.5, MA20=567.32, 月變化=4.2%
-```
-
-### 股票分析
-
-```bash
-# 查看股票排行榜
-npm run rank
-
-# 前 5 檔且分數 >= 70
-npm run rank -- --limit 5 --minScore 70
-
-# 離線模式
-npm run rank -- --offline
-
-# 分析單一股票
-npm run explain 2330
-
-# 自訂權重與計分方法
-npm run rank -- --weights "50,20,15,10,5" --method percentile
-
-```
-
-### 回測
-
-```bash
-# 執行 MA20/60 交叉回測
-npm run backtest -- --stock 00929
-```
-
-### 視覺化分析
-
-```bash
-# 顯示系統摘要
-npm run visualize
-
-# 顯示前20名排行榜
-npm run visualize -- --type top --limit 20
-
-# 顯示分數分佈
-npm run visualize -- --type distribution
-
-# 比較多檔股票
-npm run visualize -- --type comparison --stocks "2330,2454,2317"
-
-# 顯示趨勢圖
-npm run visualize -- --type trend --stocks 2330 --factor valuation
-```
-
-### 資料管理
-
-```bash
-# 更新所有資料
-npm run update
-
-# 強制更新（忽略快取）
-npm run update -- --force
-
-# 更新特定因子
-npm run update -- --factors "valuation,growth"
-
-# 更新特定股票
-npm run update -- --stocks "2330,2454"
-
-# 清理舊資料
-npm run update -- --clean
-
-# 查看更新狀態
-npm run update -- --status
-```
 
 ## 🏗️ 專案架構
 
@@ -261,19 +162,6 @@ src/
 3. **缺失值處理**: 智慧填補缺失資料
 4. **因子合成**: 加權平均計算各因子分數
 5. **總分計算**: 各因子按權重加總得出最終分數
-
-## 🧪 測試
-
-```bash
-# 執行所有測試
-npm test
-
-# 執行測試並查看覆蓋率
-npm run test:coverage
-
-# 執行特定測試
-npm test -- src/services/dataCleaner.test.ts
-```
 
 ## 📈 性能優化
 
@@ -392,19 +280,6 @@ RATE_LIMIT = {
 4. 定期更新資料以保持分析準確性
 
 ## 📝 開發指南
-
-### 程式碼品質
-
-```bash
-# 檢查程式碼風格
-npm run lint
-
-# 自動修正程式碼風格
-npm run lint:fix
-
-# 型別檢查
-npm run typecheck
-```
 
 ### 新增因子
 

--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -1,0 +1,131 @@
+# CLI 使用手冊
+
+本文件列出 `npm run` 指令的說明與範例。
+
+## 建置與開發
+
+- `npm run build`：編譯 TypeScript 專案。
+
+```bash
+npm run build
+```
+
+- `npm run dev`：以 tsx 執行 `src/index.ts`，方便開發。
+
+```bash
+npm run dev
+```
+
+## 資料抓取
+
+- `npm run fetch-all`：一次抓取所有因子與價格資料。
+
+```bash
+npm run fetch-all
+```
+
+- `npm run fetch-valuation`：抓取本益比、股價淨值比等估值資料，可使用 `--date`、`--stocks` 等參數。
+
+```bash
+npm run fetch-valuation -- --date 2024-01-05 --stocks 2330,2303
+```
+
+- `npm run fetch-growth`：抓取營收與 EPS 成長資料，需要 FinMind Token。可透過 `--type` 指定 `revenue`、`eps` 或 `both`。
+
+```bash
+npm run fetch-growth -- --type revenue --stocks 2330
+```
+
+- `npm run fetch-quality`：抓取 ROE、毛利率等財務品質指標。
+
+```bash
+npm run fetch-quality
+```
+
+- `npm run fetch-fund-flow`：抓取外資、投信買賣超等資金流資料。
+
+```bash
+npm run fetch-fund-flow -- --stocks 2330 --start-date 2024-01-01
+```
+
+- `npm run fetch-momentum`：抓取 RSI、移動平均等動能指標。
+
+```bash
+npm run fetch-momentum -- --stocks 2330,2317 --days 60
+```
+
+- `npm run fetch-price`：抓取股價與估值歷史資料。
+
+```bash
+npm run fetch-price -- --stocks 2330 --days 30 --type price
+```
+
+## 分析與視覺化
+
+- `npm run rank`：計算股票綜合分數並依分數排序，可加入 `--limit`、`--minScore` 等參數。
+
+```bash
+npm run rank -- --limit 10 --minScore 70
+```
+
+- `npm run explain`：顯示單一股票的詳細指標與評分。
+
+```bash
+npm run explain 2330
+```
+
+- `npm run visualize`：輸出 ASCII 圖表或摘要報告，支援 `--type`、`--stocks` 等參數。
+
+```bash
+npm run visualize -- --type distribution
+```
+
+- `npm run backtest`：執行簡易回測，例如 MA20/60 交叉策略。
+
+```bash
+npm run backtest -- --stock 2330
+```
+
+- `npm run update`：更新資料庫，可指定因子或股票，使用 `--force` 可忽略快取。
+
+```bash
+npm run update -- --factors valuation,growth --force
+```
+
+## 測試與程式碼品質
+
+- `npm run test`：執行所有單元測試。
+
+```bash
+npm run test
+```
+
+- `npm run test:coverage`：產生測試覆蓋率報告。
+
+```bash
+npm run test:coverage
+```
+
+- `npm run test:finmind`：編譯並測試 FinMind API 連線。
+
+```bash
+npm run test:finmind
+```
+
+- `npm run lint`：使用 ESLint 檢查程式碼。
+
+```bash
+npm run lint
+```
+
+- `npm run lint:fix`：自動修正 ESLint 錯誤。
+
+```bash
+npm run lint:fix
+```
+
+- `npm run typecheck`：進行 TypeScript 型別檢查。
+
+```bash
+npm run typecheck
+```


### PR DESCRIPTION
## Summary
- document npm scripts in `docs/CLI_USAGE.md`
- link CLI guide from the 使用指南 section of `README.md`
- clean duplicated CLI command examples from README

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68558111ec28833087874f3d8e618a6d