### PR TITLE
Add start field to WalkForward options

### DIFF
--- a/src/services/walkForward.ts
+++ b/src/services/walkForward.ts
@@ -2,6 +2,7 @@ import { RankRow } from './portfolioBuilder.js';
 import { backtest, PriceSeries, BacktestOptions } from './backtest.js';
 
 export interface WalkForwardOptions extends Omit<BacktestOptions, 'start'> {
+  start: string;
   windowYears: number;
   stepMonths: number;
 }


### PR DESCRIPTION
## Summary
- support `start` in `WalkForwardOptions`
- use the option in walkForward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561aa9f2608330bed765aff961e57e