### PR TITLE
Add customizable backtest options

### DIFF
--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -80,10 +80,11 @@ npm run explain 2330
 npm run visualize -- --type distribution
 ```
 
-- `npm run backtest`：以每日排名建構投資組合進行回測，可調整起始日期、持有數量、再平衡週期與權重模式。
+- `npm run backtest`：以每日排名建構投資組合進行回測，可調整起始與結束日期、持有數量、再平衡週期、權重模式，以及手續費設定。執行後會將結果另存為 `backtest_<date>.json`。
 
 ```bash
-npm run backtest -- --start 2018-01-01 --top 10 --rebalance 21 --mode equal
+npm run backtest -- --start 2018-01-01 --end 2020-12-31 \
+  --top 10 --rebalance 21 --mode equal --cost 0.001425 --fee 0.003 --slip 0.0015
 ```
 
 - `npm run walk-forward`：執行滾動視窗的 Walk‑Forward 分析，除 backtest 參數外還可設定 `--window` (年) 與 `--step` (月)。

--- a/src/backtest/multiStrategy.ts
+++ b/src/backtest/multiStrategy.ts
@@ -38,6 +38,7 @@ export class SectorRotationStrategy implements Strategy {
     const sectors = new Map<string, { sec: string; mo: number }>();
     for (const [stock, arr] of Object.entries(this.momentum)) {
       const sec = this.sectorMap[stock];
+      if (!sec) continue;
       const mo = arr[i] ?? -Infinity;
       const item = sectors.get(sec);
       if (!item || item.mo < mo) sectors.set(sec, { sec, mo });

--- a/src/cli/fetch-all.ts
+++ b/src/cli/fetch-all.ts
@@ -17,8 +17,8 @@ export async function run(): Promise<void> {
 
   await Promise.all([
     (async () => {
+      const spin = ora('Valuation').start();
       try {
-        const spin = ora('Valuation').start();
         await valuation.initialize();
         await valuation.fetchValuationData();
         spin.succeed('Valuation 完成');
@@ -31,8 +31,8 @@ export async function run(): Promise<void> {
       }
     })(),
     (async () => {
+      const spin = ora('Growth').start();
       try {
-        const spin = ora('Growth').start();
         await growth.initialize();
         await growth.fetchRevenueData();
         await growth.fetchEpsData();
@@ -46,8 +46,8 @@ export async function run(): Promise<void> {
       }
     })(),
     (async () => {
+      const spin = ora('Quality').start();
       try {
-        const spin = ora('Quality').start();
         await quality.initialize();
         await quality.fetchQualityMetrics('2330', '2020-01-01');
         spin.succeed('Quality 完成');
@@ -60,8 +60,8 @@ export async function run(): Promise<void> {
       }
     })(),
     (async () => {
+      const spin = ora('Fund flow').start();
       try {
-        const spin = ora('Fund flow').start();
         await fund.initialize();
         await fund.fetchFundFlowData();
         spin.succeed('Fund flow 完成');
@@ -74,8 +74,8 @@ export async function run(): Promise<void> {
       }
     })(),
     (async () => {
+      const spin = ora('Momentum').start();
       try {
-        const spin = ora('Momentum').start();
         await momentum.initialize();
         await momentum.fetchMomentumData(['2330']);
         spin.succeed('Momentum 完成');

--- a/src/cli/walk-forward.ts
+++ b/src/cli/walk-forward.ts
@@ -29,16 +29,16 @@ export async function run(args: string[] = hideBin(process.argv)): Promise<void>
 
   const priceRows = query<any>('SELECT stock_no, date, close FROM price_daily ORDER BY date');
   const prices: Record<string, { date: string; close: number }[]> = {};
-  for (const row of priceRows) {
-    if (!prices[row.stock_no]) prices[row.stock_no] = [];
-    prices[row.stock_no].push({ date: row.date, close: row.close });
-  }
+    for (const row of priceRows) {
+      if (!prices[row.stock_no]) prices[row.stock_no] = [];
+      prices[row.stock_no]!.push({ date: row.date, close: row.close });
+    }
 
   const results = walkForward(ranks, prices, {
     start: argv.start,
     rebalance: argv.rebalance,
     top: argv.top,
-    mode: argv.mode,
+      mode: argv.mode as 'equal' | 'cap',
     windowYears: argv.window,
     stepMonths: argv.step,
     costModel: new CostModel(),

--- a/src/services/walkForward.ts
+++ b/src/services/walkForward.ts
@@ -41,7 +41,7 @@ export function walkForward(
       Object.fromEntries(
         Object.entries(prices).map(([s, arr]) => [s, arr.filter(p => p.date >= winStart && p.date <= winEnd)])
       ),
-      { ...opts, start: winStart }
+      { ...opts, start: winStart, end: winEnd }
     );
     results.push({ start: winStart, end: winEnd, cagr: res.cagr, sharpe: res.sharpe, mdd: res.mdd });
     winStart = addMonths(winStart, opts.stepMonths);

--- a/tests/backtest.spec.ts
+++ b/tests/backtest.spec.ts
@@ -39,6 +39,16 @@ describe('backtest engine', () => {
     const res = backtest(r2, prices, { start: '2020-01-01', rebalance: 1, top: 1, mode: 'equal', costModel: new CostModel(0,0,0) });
     expect(res.equity.length).toBe(2);
   });
+
+  it('respects end date', () => {
+    const res = backtest(ranks, prices, { start: '2020-01-01', end: '2020-01-01', rebalance: 1, top: 1, mode: 'equal', costModel: new CostModel(0,0,0) });
+    expect(res.dates.length).toBe(1);
+  });
+
+  it('throws on invalid price data', () => {
+    const bad = { A: [{ date: '2020-01-01', close: NaN }] } as any;
+    expect(() => backtest(ranks, bad, { start: '2020-01-01', rebalance: 1, top: 1, mode: 'equal' })).toThrow();
+  });
 });
 
 describe('portfolioBuilder cap mode', () => {


### PR DESCRIPTION
## Summary
- extend CLI backtest options to support end date and transaction cost flags
- write results to JSON file
- validate price data and support end date in backtest service
- pass end date through walk-forward
- test new backtest features
- fix TypeScript compile errors
- document new backtest CLI usage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68562953937c833091cb051ce8cc7a7d