### PR TITLE
Add relative strength metrics

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -134,6 +134,25 @@
 | bb_middle | REAL | 布林通道中軌 | 448.7 |
 | bb_lower | REAL | 布林通道下軌 | 437.3 |
 
+#### `momentum_metrics` - 動能指標表
+記錄相對強弱、均線位置等動能相關數據
+
+| 欄位名 | 型別 | 說明 | 範例 |
+|--------|------|------|------|
+| stock_no | TEXT | 股票代號 | "2330" |
+| date | DATE | 交易日期 | "2023-06-15" |
+| ma_5 | REAL | 5日移動平均線 (元) | 451.2 |
+| ma_20 | REAL | 20日移動平均線 (元) | 448.7 |
+| ma_60 | REAL | 60日移動平均線 (元) | 445.3 |
+| rsi | REAL | RSI相對強弱指標 (0-100) | 67.8 |
+| macd | REAL | MACD指標 | 2.15 |
+| bb_upper | REAL | 布林通道上軌 | 460.1 |
+| bb_middle | REAL | 布林通道中軌 | 448.7 |
+| bb_lower | REAL | 布林通道下軌 | 437.3 |
+| price_change_1m | REAL | 一個月報酬率 (%) | 5.1 |
+| relative_strength_52w | REAL | 52 週相對強弱 (%) | 12.3 |
+| ma20_above_ma60_days | INTEGER | MA20 高於 MA60 天數 | 40 |
+
 ### 🛠 系統管理表
 
 #### `migration_history` - 資料庫遷移紀錄表
@@ -166,6 +185,7 @@
 - `idx_cash_flow_date` - 現金流量表日期索引
 - `idx_dividend_policy_year` - 股利政策表年度索引
 - `idx_technical_indicators_date` - 技術指標表日期索引
+- `idx_momentum_metrics_date` - 動能指標表日期索引
 
 ## 資料來源對應
 

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -48,7 +48,8 @@ npm run fetch-quality
 npm run fetch-fund-flow -- --stocks 2330 --start-date 2024-01-01
 ```
 
-- `npm run fetch-momentum`：抓取 RSI、移動平均等動能指標。
+
+- `npm run fetch-momentum`：抓取 RSI、移動平均等動能指標，預設會下載三檔範例股票。
 
 ```bash
 npm run fetch-momentum -- --stocks 2330,2317 --days 60

--- a/migrations/006_create_momentum_metrics.sql
+++ b/migrations/006_create_momentum_metrics.sql
@@ -1,0 +1,18 @@
+-- Create table for momentum metrics including new indicators
+CREATE TABLE IF NOT EXISTS momentum_metrics (
+  stock_no TEXT NOT NULL,
+  date DATE NOT NULL,
+  ma_5 REAL,
+  ma_20 REAL,
+  ma_60 REAL,
+  rsi REAL,
+  macd REAL,
+  bb_upper REAL,
+  bb_middle REAL,
+  bb_lower REAL,
+  price_change_1m REAL,
+  relative_strength_52w REAL,
+  ma20_above_ma60_days INTEGER,
+  PRIMARY KEY (stock_no, date)
+);
+CREATE INDEX IF NOT EXISTS idx_momentum_metrics_date ON momentum_metrics(date);

--- a/src/cli/fetch-momentum.ts
+++ b/src/cli/fetch-momentum.ts
@@ -19,7 +19,7 @@ async function main() {
       alias: 's',
       type: 'string',
       description: '股票代號（逗號分隔）',
-      default: DEFAULT_STOCK_CODES.join(',')
+      default: DEFAULT_STOCK_CODES.slice(0, 3).join(',')
     })
     .option('days', {
       alias: 'd',

--- a/src/fetchers/momentumFetcher.ts
+++ b/src/fetchers/momentumFetcher.ts
@@ -11,10 +11,12 @@ export interface MomentumMetrics {
   ma_20?: number;
   ma_60?: number;
   macd?: number;
-  boll_upper?: number;
-  boll_middle?: number;
-  boll_lower?: number;
+  bb_upper?: number;
+  bb_middle?: number;
+  bb_lower?: number;
   price_change_1m?: number;
+  relative_strength_52w?: number;
+  ma20_above_ma60_days?: number;
 }
 
 /**
@@ -47,9 +49,9 @@ export class MomentumFetcher {
   private initializeDatabase(): void {
     const db = this.getDb();
 
-    // 創建技術指標表
+    // 創建動能指標表
     db.exec(`
-      CREATE TABLE IF NOT EXISTS technical_indicators (
+      CREATE TABLE IF NOT EXISTS momentum_metrics (
         stock_no TEXT NOT NULL,
         date DATE NOT NULL,
         ma_5 REAL,
@@ -60,6 +62,9 @@ export class MomentumFetcher {
         bb_upper REAL,
         bb_middle REAL,
         bb_lower REAL,
+        price_change_1m REAL,
+        relative_strength_52w REAL,
+        ma20_above_ma60_days INTEGER,
         PRIMARY KEY (stock_no, date)
       )
     `);
@@ -126,6 +131,8 @@ export class MomentumFetcher {
 
           // 計算一個月價格變化率
           const priceChange1M = this.calculatePriceChange(closePrices, 22); // 約22個交易日為一個月
+          const rs52w = this.calculatePriceChange(closePrices, 252);
+          const ma20AboveDays = this.countMA20AboveMA60Days(closePrices);
 
           const metrics: MomentumMetrics = {
             stock_id: stockId,
@@ -135,10 +142,12 @@ export class MomentumFetcher {
             ...(latestMA20 !== undefined && { ma_20: latestMA20 }),
             ...(latestMA60 !== undefined && { ma_60: latestMA60 }),
             ...(latestMACD !== undefined && { macd: latestMACD }),
-            ...(latestBBUpper !== undefined && { boll_upper: latestBBUpper }),
-            ...(latestBBMiddle !== undefined && { boll_middle: latestBBMiddle }),
-            ...(latestBBLower !== undefined && { boll_lower: latestBBLower }),
-            ...(priceChange1M !== undefined && { price_change_1m: priceChange1M })
+            ...(latestBBUpper !== undefined && { bb_upper: latestBBUpper }),
+            ...(latestBBMiddle !== undefined && { bb_middle: latestBBMiddle }),
+            ...(latestBBLower !== undefined && { bb_lower: latestBBLower }),
+            ...(priceChange1M !== undefined && { price_change_1m: priceChange1M }),
+            ...(rs52w !== undefined && { relative_strength_52w: rs52w }),
+            ma20_above_ma60_days: ma20AboveDays
           };
 
           allMetrics.push(metrics);
@@ -231,6 +240,23 @@ export class MomentumFetcher {
   }
 
   /**
+   * 計算在指定價格序列中 MA20 高於 MA60 的天數
+   */
+  private countMA20AboveMA60Days(prices: number[]): number {
+    const ma20 = this.calculateSMA(prices, 20);
+    const ma60 = this.calculateSMA(prices, 60);
+    let count = 0;
+    for (let i = 0; i < prices.length; i++) {
+      const ma20Val = i >= 19 ? ma20[i - 19] : undefined;
+      const ma60Val = i >= 59 ? ma60[i - 59] : undefined;
+      if (ma20Val !== undefined && ma60Val !== undefined && ma20Val > ma60Val) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
    * 計算指數移動平均線 (EMA)
    */
   private calculateEMA(prices: number[], period: number): number[] {
@@ -302,9 +328,9 @@ export class MomentumFetcher {
 
     const db = this.getDb();
     const stmt = db.prepare(
-      `INSERT OR REPLACE INTO technical_indicators
-       (stock_no, date, ma_5, ma_20, ma_60, rsi, macd, bb_upper, bb_middle, bb_lower, price_change_1m)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT OR REPLACE INTO momentum_metrics
+       (stock_no, date, ma_5, ma_20, ma_60, rsi, macd, bb_upper, bb_middle, bb_lower, price_change_1m, relative_strength_52w, ma20_above_ma60_days)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
 
     for (const item of data) {
@@ -317,10 +343,12 @@ export class MomentumFetcher {
           item.ma_60 || null,
           item.rsi || null,
           item.macd || null,
-          item.boll_upper || null,
-          item.boll_middle || null,
-          item.boll_lower || null,
-          item.price_change_1m || null
+          item.bb_upper || null,
+          item.bb_middle || null,
+          item.bb_lower || null,
+          item.price_change_1m || null,
+          item.relative_strength_52w || null,
+          item.ma20_above_ma60_days ?? null
         );
       } catch (error) {
         console.error(`儲存動能指標資料失敗:`, error);

--- a/tests/momentumFetcher.test.ts
+++ b/tests/momentumFetcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { MomentumFetcher, MomentumMetrics } from '../src/fetchers/momentumFetcher.js';
+
+function tmpDbPath() {
+  return path.join(os.tmpdir(), `momentum-test-${Date.now()}-${Math.random()}.db`);
+}
+
+describe('MomentumFetcher', () => {
+  afterEach(() => {
+    // Ensure no tmp files remain
+    fs.readdirSync(os.tmpdir())
+      .filter(f => f.startsWith('momentum-test-') && f.endsWith('.db'))
+      .forEach(f => {
+        try {
+          fs.unlinkSync(path.join(os.tmpdir(), f));
+        } catch {}
+      });
+  });
+
+  it('calculates MA20 and MA60 window lengths', () => {
+    const fetcher = new MomentumFetcher(undefined, ':memory:');
+    const prices = Array.from({ length: 100 }, (_, i) => i + 1);
+    const ma20 = (fetcher as any).calculateSMA(prices, 20) as number[];
+    const ma60 = (fetcher as any).calculateSMA(prices, 60) as number[];
+    expect(ma20.length).toBe(81);
+    expect(ma60.length).toBe(41);
+  });
+
+  it('inserts records into momentum_metrics table', () => {
+    const dbPath = tmpDbPath();
+    const fetcher = new MomentumFetcher(undefined, dbPath);
+    fetcher.initialize();
+    const metrics: MomentumMetrics[] = [
+      { stock_id: 'A', date: '2024-01-01', ma20_above_ma60_days: 1 },
+      { stock_id: 'B', date: '2024-01-01', ma20_above_ma60_days: 2 },
+      { stock_id: 'C', date: '2024-01-01', ma20_above_ma60_days: 3 }
+    ];
+    (fetcher as any).saveMomentumData(metrics);
+    const db = (fetcher as any).getDb();
+    const row = db.prepare('SELECT COUNT(*) as cnt FROM momentum_metrics').get();
+    expect(row.cnt).toBe(3);
+    fetcher.close();
+    fs.unlinkSync(dbPath);
+  });
+});


### PR DESCRIPTION
## Summary
- compute 52 week relative strength and MA20>MA60 days
- store metrics in new `momentum_metrics` table
- default CLI fetches 3 sample stocks
- add unit tests for SMA windows and DB insertions
- document momentum metrics table

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68564304f0f4833098d85579a6c71c96