### PR TITLE
Add apply() to CostModel

### DIFF
--- a/src/models/CostModel.ts
+++ b/src/models/CostModel.ts
@@ -9,11 +9,18 @@ export class CostModel {
     public slippage: number = DEFAULT_SLIPPAGE
   ) {}
 
+  apply(value: number, side: 'buy' | 'sell'): number {
+    if (side === 'buy') {
+      return value * (1 + this.slippage) * (1 + this.brokerage);
+    }
+    return value * (1 - this.slippage) * (1 - this.brokerage - this.tax);
+  }
+
   buy(price: number): number {
-    return price * (1 + this.slippage) * (1 + this.brokerage);
+    return this.apply(price, 'buy');
   }
 
   sell(price: number): number {
-    return price * (1 - this.slippage) * (1 - this.brokerage - this.tax);
+    return this.apply(price, 'sell');
   }
 }

--- a/src/services/backtest.ts
+++ b/src/services/backtest.ts
@@ -81,7 +81,7 @@ export function backtest(
         if (!port[s]) {
           const price = lastPrice[s];
           if (price != null) {
-            cash += model.sell(price) * qty;
+            cash += model.apply(price, 'sell') * qty;
             delete holdings[s];
           }
         }
@@ -94,12 +94,12 @@ export function backtest(
         const diff = target - cur;
         if (Math.abs(diff) < 1e-8) continue;
         if (diff > 0) {
-          const cost = model.buy(price) * diff;
+          const cost = model.apply(price, 'buy') * diff;
           cash -= cost;
           holdings[s] = cur + diff;
         } else {
           const qty = -diff;
-          cash += model.sell(price) * qty;
+          cash += model.apply(price, 'sell') * qty;
           holdings[s] = cur - qty;
         }
       }

--- a/tests/backtest.spec.ts
+++ b/tests/backtest.spec.ts
@@ -64,9 +64,22 @@ describe('portfolioBuilder cap mode', () => {
 });
 
 describe('cost model', () => {
-  it('calculates buy and sell prices', () => {
+  it('calculates buy and sell prices via apply()', () => {
     const cm = new CostModel(0.001, 0.002, 0.001);
-    expect(cm.buy(100)).toBeCloseTo(100 * 1.001 * 1.001);
-    expect(cm.sell(100)).toBeCloseTo(100 * 0.999 * (1 - 0.001 - 0.002));
+    expect(cm.apply(100, 'buy')).toBeCloseTo(100 * 1.001 * 1.001);
+    expect(cm.apply(100, 'sell')).toBeCloseTo(100 * 0.999 * (1 - 0.001 - 0.002));
+  });
+
+  it('buy() and sell() delegate to apply()', () => {
+    const cm = new CostModel();
+    expect(cm.buy(50)).toBeCloseTo(cm.apply(50, 'buy'));
+    expect(cm.sell(50)).toBeCloseTo(cm.apply(50, 'sell'));
+  });
+
+  it('rate changes alter the output', () => {
+    const cm = new CostModel();
+    const baseBuy = cm.apply(100, 'buy');
+    cm.brokerage = 0.002;
+    expect(cm.apply(100, 'buy')).not.toBeCloseTo(baseBuy);
   });
 });


### PR DESCRIPTION
## Summary
- add generic `apply()` method handling buy/sell
- delegate `buy()` and `sell()` to `apply()`
- update backtest engine to use `apply()`
- expand cost model tests for new API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856660625a48330a883dfdcc149d8e0