### PR TITLE
Add relative strength metrics

### DIFF
--- a/migrations/006_create_momentum_metrics.sql
+++ b/migrations/006_create_momentum_metrics.sql
@@ -1,0 +1,18 @@
+-- Create table for momentum metrics including new indicators
+CREATE TABLE IF NOT EXISTS momentum_metrics (
+  stock_no TEXT NOT NULL,
+  date DATE NOT NULL,
+  ma_5 REAL,
+  ma_20 REAL,
+  ma_60 REAL,
+  rsi REAL,
+  macd REAL,
+  bb_upper REAL,
+  bb_middle REAL,
+  bb_lower REAL,
+  price_change_1m REAL,
+  relative_strength_52w REAL,
+  ma20_above_ma60_days INTEGER,
+  PRIMARY KEY (stock_no, date)
+);
+CREATE INDEX IF NOT EXISTS idx_momentum_metrics_date ON momentum_metrics(date);

--- a/src/cli/fetch-momentum.ts
+++ b/src/cli/fetch-momentum.ts
@@ -19,7 +19,7 @@ async function main() {
       alias: 's',
       type: 'string',
       description: '股票代號（逗號分隔）',
-      default: DEFAULT_STOCK_CODES.join(',')
+      default: DEFAULT_STOCK_CODES.slice(0, 3).join(',')
     })
     .option('days', {
       alias: 'd',

--- a/tests/momentumFetcher.test.ts
+++ b/tests/momentumFetcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { MomentumFetcher, MomentumMetrics } from '../src/fetchers/momentumFetcher.js';
+
+function tmpDbPath() {
+  return path.join(os.tmpdir(), `momentum-test-${Date.now()}-${Math.random()}.db`);
+}
+
+describe('MomentumFetcher', () => {
+  afterEach(() => {
+    // Ensure no tmp files remain
+    fs.readdirSync(os.tmpdir())
+      .filter(f => f.startsWith('momentum-test-') && f.endsWith('.db'))
+      .forEach(f => {
+        try {
+          fs.unlinkSync(path.join(os.tmpdir(), f));
+        } catch {}
+      });
+  });
+
+  it('calculates MA20 and MA60 window lengths', () => {
+    const fetcher = new MomentumFetcher(undefined, ':memory:');
+    const prices = Array.from({ length: 100 }, (_, i) => i + 1);
+    const ma20 = (fetcher as any).calculateSMA(prices, 20) as number[];
+    const ma60 = (fetcher as any).calculateSMA(prices, 60) as number[];
+    expect(ma20.length).toBe(81);
+    expect(ma60.length).toBe(41);
+  });
+
+  it('inserts records into momentum_metrics table', () => {
+    const dbPath = tmpDbPath();
+    const fetcher = new MomentumFetcher(undefined, dbPath);
+    fetcher.initialize();
+    const metrics: MomentumMetrics[] = [
+      { stock_id: 'A', date: '2024-01-01', ma20_above_ma60_days: 1 },
+      { stock_id: 'B', date: '2024-01-01', ma20_above_ma60_days: 2 },
+      { stock_id: 'C', date: '2024-01-01', ma20_above_ma60_days: 3 }
+    ];
+    (fetcher as any).saveMomentumData(metrics);
+    const db = (fetcher as any).getDb();
+    const row = db.prepare('SELECT COUNT(*) as cnt FROM momentum_metrics').get();
+    expect(row.cnt).toBe(3);
+    fetcher.close();
+    fs.unlinkSync(dbPath);
+  });
+});


### PR DESCRIPTION
## Summary
- compute 52 week relative strength and MA20>MA60 days
- store metrics in new `momentum_metrics` table
- default CLI fetches 3 sample stocks
- add unit tests for SMA windows and DB insertions

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68564304f0f4833098d85579a6c71c96