### PR TITLE
Improve tests for portfolio components

### DIFF
--- a/tests/bootstrapPnL.test.ts
+++ b/tests/bootstrapPnL.test.ts
@@ -18,4 +18,8 @@ describe('bootstrapPnL', () => {
     expect(mdd).toBeGreaterThanOrEqual(ci95_low);
     expect(mdd).toBeLessThanOrEqual(ci95_high);
   });
+
+  it('throws on too short equity curve', () => {
+    expect(() => bootstrapPnL([1], 10)).toThrow();
+  });
 });

--- a/tests/walkForward.spec.ts
+++ b/tests/walkForward.spec.ts
@@ -16,4 +16,20 @@ describe('walkForward', () => {
     const res = walkForward(ranks, prices, { start: '2020-01-01', rebalance: 30, top: 1, mode: 'equal', windowYears: 1, stepMonths: 3 });
     expect(res.length).toBeGreaterThan(3);
   });
+
+  it('row count matches floor((total-window)/step)+1', () => {
+    const start = '2020-01-01';
+    const step = 3;
+    const windowMonths = 12;
+    const res = walkForward(ranks, prices, { start, rebalance: 30, top: 1, mode: 'equal', windowYears: 1, stepMonths: step });
+    const last = prices.A[prices.A.length - 1]!.date;
+    const months = (d1: string, d2: string) => {
+      const a = new Date(d1);
+      const b = new Date(d2);
+      return (b.getFullYear() - a.getFullYear()) * 12 + b.getMonth() - a.getMonth();
+    };
+    const total = months(start, last);
+    const expected = Math.floor((total - windowMonths) / step) + 1;
+    expect(res.length).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- verify portfolio builder sizing per-date and weight sum
- test backtest with costs and drawdown monotonicity
- assert walk-forward window count calculation
- stub python heatmap generation for CLI optimize
- check bootstrapPnL error handling

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6857a8d5b3d08330b295df13975b95e3